### PR TITLE
fix: when calculating the real service name data.aws_vpc_endpoint_service may not exist

### DIFF
--- a/modules/vpc-endpoints/main.tf
+++ b/modules/vpc-endpoints/main.tf
@@ -4,7 +4,7 @@ locals {
   # If user explicitly provides a service endpoint, use it. Otherwise, use the discovered service_name.
   real_service_names = {
     for key, endpoint in var.endpoints :
-    key => coalesce(endpoint.service_full_name, data.aws_vpc_endpoint_service.default[key].service_name)
+    key => coalesce(endpoint.service_full_name, try(data.aws_vpc_endpoint_service.default[key].service_name, null))
   }
 
   # Private DNS is disabled for centralized endpoints, endpoints with a custom privatelink dns_zone, or non-Interface endpoint types.


### PR DESCRIPTION
Since the data source may not exist, add a try statement in the real_service_name calculation:

```
Error: Invalid index
on .terraform/modules/vpc_endpoints_private_link/modules/vpc-endpoints/main.tf line 7, in locals:

    key => coalesce(endpoint.service_full_name, data.aws_vpc_endpoint_service.default[key].service_name)

data.aws_vpc_endpoint_service.default is object with no attributes
The given key does not identify an element in this collection value.
```
