### PR TITLE
breaking: modify transit_gateway_route_table_propagation type to solve known after apply issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ This module will be merged with the [terraform-aws-mcaf-vpc](https://github.com/
 | <a name="input_transit_gateway_appliance_mode_support"></a> [transit\_gateway\_appliance\_mode\_support](#input\_transit\_gateway\_appliance\_mode\_support) | Enable to attach the VPC in appliance mode on the Transit Gateway. | `bool` | `false` | no |
 | <a name="input_transit_gateway_id"></a> [transit\_gateway\_id](#input\_transit\_gateway\_id) | Transit Gateway ID. | `string` | `""` | no |
 | <a name="input_transit_gateway_route_table_association"></a> [transit\_gateway\_route\_table\_association](#input\_transit\_gateway\_route\_table\_association) | Transit Gateway route table ID to attach the VPC on. | `string` | `""` | no |
-| <a name="input_transit_gateway_route_table_propagation"></a> [transit\_gateway\_route\_table\_propagation](#input\_transit\_gateway\_route\_table\_propagation) | Transit Gateway route table ID's to propagate the VPC CIDR to. | `list(string)` | `[]` | no |
+| <a name="input_transit_gateway_route_table_propagation"></a> [transit\_gateway\_route\_table\_propagation](#input\_transit\_gateway\_route\_table\_propagation) | Map of [logical name]→[Transit Gateway route table ID] to propagate the VPC CIDR to. | `map(string)` | `{}` | no |
 | <a name="input_vpc_cidr_netmask"></a> [vpc\_cidr\_netmask](#input\_vpc\_cidr\_netmask) | The netmask length of the IPv4 CIDR you want to allocate to this VPC. | `number` | `20` | no |
 
 ## Outputs

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -1,0 +1,11 @@
+# Upgrading Notes
+
+This document captures required refactoring on your part when upgrading to a module version that contains breaking changes.
+
+## Upgrading to v1.0.0
+
+### Variables
+
+The following variables have been modified:
+
+- `transit_gateway_route_table_propagation` type: list(string) -> map(string).

--- a/examples/transit-gateway/main.tf
+++ b/examples/transit-gateway/main.tf
@@ -27,7 +27,7 @@ module "vpc" {
   aws_vpc_ipam_pool                       = "ipam-pool-1a1a1a1a1a1a1a1a1"
   transit_gateway_id                      = module.transit_gateway.transit_gateway_id
   transit_gateway_route_table_association = module.transit_gateway.transit_gateway_route_table_id["vpc"]
-  transit_gateway_route_table_propagation = module.transit_gateway.transit_gateway_route_table_id["shared"]
+  transit_gateway_route_table_propagation = { shared = module.transit_gateway.transit_gateway_route_table_id["shared"] }
   vpc_cidr_netmask                        = 20
 
   networks = [

--- a/examples/vpc-endpoints-centralized/main.tf
+++ b/examples/vpc-endpoints-centralized/main.tf
@@ -44,7 +44,7 @@ module "hub_vpc" {
 
 module "security_group" {
   source  = "schubergphilis/mcaf-security-group/aws"
-  version = "~> 0.1"
+  version = "~> 2.0"
 
   description = "VPC endpoint security group"
   name_prefix = "hub-vpc-endpoints-"
@@ -52,7 +52,7 @@ module "security_group" {
 
   ingress_rules = {
     spoke_vpcs = {
-      cidr_ipv4   = "10.64.0.0/12"
+      cidr_ipv4   = ["10.64.0.0/12"]
       description = "Allow access from all spoke VPCs"
       from_port   = 443
       ip_protocol = "tcp"

--- a/examples/vpc-endpoints-privatelink/main.tf
+++ b/examples/vpc-endpoints-privatelink/main.tf
@@ -44,7 +44,7 @@ module "vpc" {
 
 module "security_group" {
   source  = "schubergphilis/mcaf-security-group/aws"
-  version = "~> 0.1"
+  version = "~> 2.0"
 
   description = "VPC endpoint security group"
   name_prefix = "vpc-endpoints-"
@@ -52,7 +52,7 @@ module "security_group" {
 
   ingress_rules = {
     ingress_https = {
-      cidr_ipv4   = module.vpc.vpc_cidr_block
+      cidr_ipv4   = [module.vpc.vpc_cidr_block]
       description = "HTTPS from VPC"
       from_port   = 443
       ip_protocol = "tcp"

--- a/examples/vpc-endpoints/main.tf
+++ b/examples/vpc-endpoints/main.tf
@@ -52,7 +52,7 @@ module "vpc" {
 
 module "security_group" {
   source  = "schubergphilis/mcaf-security-group/aws"
-  version = "~> 0.1"
+  version = "~> 2.0"
 
   description = "VPC endpoint security group"
   name_prefix = "vpc-endpoints-"
@@ -60,7 +60,7 @@ module "security_group" {
 
   ingress_rules = {
     ingress_https = {
-      cidr_ipv4   = module.vpc.vpc_cidr_block
+      cidr_ipv4   = [module.vpc.vpc_cidr_block]
       description = "HTTPS from VPC"
       from_port   = 443
       ip_protocol = "tcp"

--- a/main.tf
+++ b/main.tf
@@ -163,7 +163,8 @@ resource "aws_ec2_transit_gateway_vpc_attachment" "default" {
 
 resource "aws_ec2_transit_gateway_vpc_attachment_accepter" "default" {
   provider = aws.transit_gateway_account
-  count    = anytrue(var.networks[*].tgw_attachment) ? 1 : 0
+
+  count = anytrue(var.networks[*].tgw_attachment) ? 1 : 0
 
   transit_gateway_attachment_id                   = aws_ec2_transit_gateway_vpc_attachment.default[count.index].id
   transit_gateway_default_route_table_association = false
@@ -173,7 +174,8 @@ resource "aws_ec2_transit_gateway_vpc_attachment_accepter" "default" {
 
 resource "aws_ec2_transit_gateway_route_table_association" "default" {
   provider = aws.transit_gateway_account
-  count    = anytrue(var.networks[*].tgw_attachment) ? 1 : 0
+
+  count = anytrue(var.networks[*].tgw_attachment) ? 1 : 0
 
   transit_gateway_attachment_id  = aws_ec2_transit_gateway_vpc_attachment.default[0].id
   transit_gateway_route_table_id = var.transit_gateway_route_table_association
@@ -183,7 +185,8 @@ resource "aws_ec2_transit_gateway_route_table_association" "default" {
 
 resource "aws_ec2_transit_gateway_route_table_propagation" "default" {
   provider = aws.transit_gateway_account
-  for_each = anytrue(var.networks[*].tgw_attachment) ? toset(var.transit_gateway_route_table_propagation) : []
+
+  for_each = anytrue(var.networks[*].tgw_attachment) ? var.transit_gateway_route_table_propagation : {}
 
   transit_gateway_attachment_id  = aws_ec2_transit_gateway_vpc_attachment.default[0].id
   transit_gateway_route_table_id = each.value

--- a/variables.tf
+++ b/variables.tf
@@ -105,9 +105,9 @@ variable "transit_gateway_route_table_association" {
 }
 
 variable "transit_gateway_route_table_propagation" {
-  type        = list(string)
-  default     = []
-  description = "Transit Gateway route table ID's to propagate the VPC CIDR to."
+  type        = map(string)
+  default     = {}
+  description = "Map of [logical name]→[Transit Gateway route table ID] to propagate the VPC CIDR to."
 }
 
 variable "vpc_cidr_netmask" {


### PR DESCRIPTION
**:hammer_and_wrench: Summary**
When creating the transit gateway and VPC's in a single plan, the following error occurs:

```
Error: Invalid for_each argument
on .terraform/modules/network.vpc_shared_services/main.tf line 186, in resource "aws_ec2_transit_gateway_route_table_propagation" "default":

  for_each = anytrue(var.networks[*].tgw_attachment) ? toset(var.transit_gateway_route_table_propagation) : []

var.networks is list of object with 2 elements
var.transit_gateway_route_table_propagation is list of string with 2 elements
The "for_each" set includes values derived from resource attributes that cannot be determined until apply, and so Terraform cannot determine the full set of keys that will identify the instances of this resource.

When working with unknown values in for_each, it's better to use a map value where the keys are defined statically in your configuration and where only the values contain apply-time results.

Alternatively, you could use the -target planning option to first apply only the resources that the for_each value depends on, and then apply a second time to fully converge.
```

In this PR:

- transit_gateway_route_table_propagation change type from list(string) to map(string.
- update examples. 
