### PR TITLE
bug: custom zones are always created

### DIFF
--- a/modules/vpc-endpoints/main.tf
+++ b/modules/vpc-endpoints/main.tf
@@ -141,7 +141,7 @@ resource "aws_vpc_endpoint" "default" {
 resource "aws_route53_zone" "custom_zone" {
   #checkov:skip=CKV2_AWS_39: "Ensure Domain Name System (DNS) query logging is enabled for Amazon Route 53 hosted zones" - Non centralized vpc endpoint zones are also not logged by AWS.
   #checkov:skip=CKV2_AWS_38: "Ensure Domain Name System Security Extensions (DNSSEC) signing is enabled for Amazon Route 53 public hosted zones" - N/A for VPC Endpoints.
-  for_each = local.custom_zones
+  for_each = { for k, v in local.custom_zones : k => v if v }
 
   name          = local.custom_zones_name[each.key]
   force_destroy = false

--- a/modules/vpc-endpoints/outputs.tf
+++ b/modules/vpc-endpoints/outputs.tf
@@ -6,7 +6,7 @@ output "endpoints" {
 output "custom_route53_zones" {
   description = "A map of all attributes for each custom DNS zone created, indexed by the endpoint key."
   value = {
-    for key, _ in local.custom_zones :
-    key => aws_route53_zone.custom_zone[key]
+    for k, v in local.custom_zones :
+    k => aws_route53_zone.custom_zone[k] if v
   }
 }


### PR DESCRIPTION
Custom zones are always created although they should be created only when endpoint is centralized or if the privatelink `dns_zone` is explicitly provided.

This pull request improves the handling of custom Route 53 DNS zones in the VPC endpoints module by ensuring that only enabled or truthy zones are processed and output. The changes help prevent unnecessary resource creation and output entries for zones that are not enabled.


