### PR TITLE
feat!: add region support

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,20 +19,20 @@ This module will be merged with the [terraform-aws-mcaf-vpc](https://github.com/
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.6 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.82 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 6.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.82 |
-| <a name="provider_aws.transit_gateway_account"></a> [aws.transit\_gateway\_account](#provider\_aws.transit\_gateway\_account) | >= 5.82 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 6.0 |
+| <a name="provider_aws.transit_gateway_account"></a> [aws.transit\_gateway\_account](#provider\_aws.transit\_gateway\_account) | >= 6.0 |
 
 ## Modules
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_log_bucket"></a> [log\_bucket](#module\_log\_bucket) | schubergphilis/mcaf-s3/aws | ~> 1.2.0 |
+| <a name="module_log_bucket"></a> [log\_bucket](#module\_log\_bucket) | schubergphilis/mcaf-s3/aws | ~> 2.0.0 |
 
 ## Resources
 
@@ -78,6 +78,7 @@ This module will be merged with the [terraform-aws-mcaf-vpc](https://github.com/
 | <a name="input_cloudwatch_flow_logs_configuration"></a> [cloudwatch\_flow\_logs\_configuration](#input\_cloudwatch\_flow\_logs\_configuration) | Cloudwatch flow logs configuration | <pre>object({<br/>    iam_path                      = optional(string, "/")<br/>    iam_policy_name_prefix        = optional(string, "vpc-flow-logs-to-cloudwatch-")<br/>    iam_role_name_prefix          = optional(string, "vpc-flow-logs-role-")<br/>    iam_role_permissions_boundary = optional(string)<br/>    kms_key_arn                   = string<br/>    log_format                    = optional(string)<br/>    log_group_name                = optional(string)<br/>    max_aggregation_interval      = optional(number, 60)<br/>    retention_in_days             = optional(number, 90)<br/>    traffic_type                  = optional(string, "ALL")<br/>  })</pre> | `null` | no |
 | <a name="input_enable_dns_hostnames"></a> [enable\_dns\_hostnames](#input\_enable\_dns\_hostnames) | Enable DNS hostnames in the VPC. | `bool` | `true` | no |
 | <a name="input_manage_default_vpc"></a> [manage\_default\_vpc](#input\_manage\_default\_vpc) | Should be true to adopt and manage the default VPC. | `bool` | `true` | no |
+| <a name="input_region"></a> [region](#input\_region) | The AWS region where resources will be created; if omitted the default provider region is used | `string` | `null` | no |
 | <a name="input_route53_profiles_association"></a> [route53\_profiles\_association](#input\_route53\_profiles\_association) | Variable to enable Route53 Profile association. Specify the 'profile\_name' of a Route53 Profile in the account to associate with the VPC, and an arbitrary 'association\_name'. Note: AWS only supports one Route53 Profile per VPC. | <pre>object({<br/>    association_name = string<br/>    profile_name     = string<br/>  })</pre> | `null` | no |
 | <a name="input_s3_flow_logs_configuration"></a> [s3\_flow\_logs\_configuration](#input\_s3\_flow\_logs\_configuration) | Variables to enable S3 flow logs for the VPC. Use 'bucket\_name' to log to an S3 bucket created by this module. Alternatively, use 'log\_destination' to specify a self-managed S3 bucket. The 'log\_destination' variable accepts full S3 ARNs, optionally including object keys. | <pre>object({<br/>    bucket_name              = optional(string)<br/>    kms_key_arn              = string<br/>    log_destination          = optional(string)<br/>    log_format               = optional(string)<br/>    max_aggregation_interval = optional(number, 60)<br/>    retention_in_days        = optional(number, 90)<br/>    traffic_type             = optional(string, "ALL")<br/><br/>    destination_options = optional(object({<br/>      file_format                = optional(string)<br/>      hive_compatible_partitions = optional(bool, false)<br/>      per_hour_partition         = optional(bool, true)<br/>    }), {})<br/>  })</pre> | `null` | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | A map of tags to add to all resources. | `map(string)` | `{}` | no |

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -2,6 +2,13 @@
 
 This document captures required refactoring on your part when upgrading to a module version that contains breaking changes.
 
+## Upgrading to v3.0.0
+
+### Key Changes v3.0.0
+
+This module now requires a minimum AWS provider version of 6.0 to support the region parameter. If you are using multiple AWS provider blocks, please read [migrating from multiple provider configurations](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/guides/enhanced-region-support#migrating-from-multiple-provider-configurations).
+
+
 ## Upgrading to v2.0.0
 
 ### Variables

--- a/data.tf
+++ b/data.tf
@@ -1,3 +1,7 @@
 data "aws_caller_identity" "default" {}
 
 data "aws_region" "default" {}
+
+data "aws_route53profiles_profiles" "default" {
+  region = var.region
+}

--- a/examples/basic/terraform.tf
+++ b/examples/basic/terraform.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source                = "hashicorp/aws"
-      version               = ">= 5.82"
+      version               = ">= 6.0"
       configuration_aliases = [aws.transit_gateway_account]
     }
   }

--- a/examples/route53-profiles-association/terraform.tf
+++ b/examples/route53-profiles-association/terraform.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source                = "hashicorp/aws"
-      version               = ">= 5.82"
+      version               = ">= 6.0"
       configuration_aliases = [aws.transit_gateway_account]
     }
   }

--- a/examples/transit-gateway/terraform.tf
+++ b/examples/transit-gateway/terraform.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source                = "hashicorp/aws"
-      version               = ">= 5.82"
+      version               = ">= 6.0"
       configuration_aliases = [aws.transit_gateway_account]
     }
   }

--- a/examples/vpc-endpoints-centralized/terraform.tf
+++ b/examples/vpc-endpoints-centralized/terraform.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source                = "hashicorp/aws"
-      version               = ">= 5.82"
+      version               = ">= 6.0"
       configuration_aliases = [aws.transit_gateway_account]
     }
   }

--- a/examples/vpc-endpoints-privatelink/terraform.tf
+++ b/examples/vpc-endpoints-privatelink/terraform.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source                = "hashicorp/aws"
-      version               = ">= 5.82"
+      version               = ">= 6.0"
       configuration_aliases = [aws.transit_gateway_account]
     }
   }

--- a/examples/vpc-endpoints/terraform.tf
+++ b/examples/vpc-endpoints/terraform.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source                = "hashicorp/aws"
-      version               = ">= 5.82"
+      version               = ">= 6.0"
       configuration_aliases = [aws.transit_gateway_account]
     }
   }

--- a/flowlogs_cloudwatch.tf
+++ b/flowlogs_cloudwatch.tf
@@ -1,6 +1,7 @@
 resource "aws_cloudwatch_log_group" "vpc_flow_logs" {
   count = var.cloudwatch_flow_logs_configuration != null ? 1 : 0
 
+  region            = var.region
   name              = try(var.cloudwatch_flow_logs_configuration.log_group_name, "/ep/${var.name}-flow-logs")
   kms_key_id        = var.cloudwatch_flow_logs_configuration.kms_key_arn
   retention_in_days = var.cloudwatch_flow_logs_configuration.retention_in_days
@@ -57,13 +58,14 @@ data "aws_iam_policy_document" "vpc_flow_log" {
       "logs:DescribeLogStreams",
     ]
 
-    resources = ["arn:aws:logs:${data.aws_region.default.name}:${data.aws_caller_identity.default.account_id}:log-group:*:*"]
+    resources = ["arn:aws:logs:${local.region}:${data.aws_caller_identity.default.account_id}:log-group:*:*"]
   }
 }
 
 resource "aws_flow_log" "default" {
   count = var.cloudwatch_flow_logs_configuration != null ? 1 : 0
 
+  region                   = var.region
   iam_role_arn             = aws_iam_role.vpc_flow_logs[0].arn
   log_destination          = aws_cloudwatch_log_group.vpc_flow_logs[0].arn
   log_format               = var.cloudwatch_flow_logs_configuration.log_format

--- a/flowlogs_s3.tf
+++ b/flowlogs_s3.tf
@@ -5,10 +5,11 @@ locals {
 
 module "log_bucket" {
   source  = "schubergphilis/mcaf-s3/aws"
-  version = "~> 1.2.0"
+  version = "~> 2.0.0"
 
   count = local.create_bucket ? 1 : 0
 
+  region      = var.region
   name        = var.s3_flow_logs_configuration.bucket_name
   kms_key_arn = var.s3_flow_logs_configuration.kms_key_arn
   tags        = var.tags
@@ -50,7 +51,7 @@ module "log_bucket" {
                     "s3:x-amz-acl": "bucket-owner-full-control"
                 },
                 "ArnLike": {
-                    "aws:SourceArn": "arn:aws:logs:${data.aws_region.default.name}:${data.aws_caller_identity.default.account_id}:*"
+                    "aws:SourceArn": "arn:aws:logs:${local.region}:${data.aws_caller_identity.default.account_id}:*"
                 }
             }
         },
@@ -67,7 +68,7 @@ module "log_bucket" {
                     "aws:SourceAccount": "${data.aws_caller_identity.default.account_id}"
                 },
                 "ArnLike": {
-                    "aws:SourceArn": "arn:aws:logs:${data.aws_region.default.name}:${data.aws_caller_identity.default.account_id}:*"
+                    "aws:SourceArn": "arn:aws:logs:${local.region}:${data.aws_caller_identity.default.account_id}:*"
                 }
             }
         }
@@ -79,6 +80,7 @@ EOF
 resource "aws_flow_log" "flow_logs_s3" {
   count = local.store_logs_in_s3 ? 1 : 0
 
+  region                   = var.region
   log_destination          = local.create_bucket ? module.log_bucket[count.index].arn : var.s3_flow_logs_configuration.log_destination
   log_destination_type     = "s3"
   log_format               = var.s3_flow_logs_configuration.log_format

--- a/main.tf
+++ b/main.tf
@@ -15,6 +15,7 @@ locals {
   )
 
   cidr_subnets = cidrsubnets(aws_vpc_ipam_preview_next_cidr.vpc.cidr, local.networks[*].new_bits...)
+  region       = var.region != null ? var.region : data.aws_region.default.region
 
   vpc_subnets = [for i, n in local.networks : {
     availability_zone = n.availability_zone
@@ -28,9 +29,8 @@ locals {
   }]
 }
 
-data "aws_route53profiles_profiles" "default" {}
-
 resource "aws_vpc_ipam_preview_next_cidr" "vpc" {
+  region         = var.region
   ipam_pool_id   = var.aws_vpc_ipam_pool
   netmask_length = var.vpc_cidr_netmask
 }
@@ -40,6 +40,7 @@ resource "aws_vpc_ipam_preview_next_cidr" "vpc" {
 ################################################################################
 
 resource "aws_vpc" "default" {
+  region                               = var.region
   enable_dns_hostnames                 = var.enable_dns_hostnames
   enable_dns_support                   = true
   enable_network_address_usage_metrics = true
@@ -50,6 +51,7 @@ resource "aws_vpc" "default" {
 }
 
 resource "aws_default_security_group" "workload_vpc" {
+  region = var.region
   vpc_id = aws_vpc.default.id
 }
 
@@ -60,6 +62,7 @@ resource "aws_default_security_group" "workload_vpc" {
 resource "aws_subnet" "default" {
   for_each = { for subnet in local.vpc_subnets : subnet.key => subnet }
 
+  region                  = var.region
   availability_zone       = each.value.availability_zone
   cidr_block              = each.value.cidr_block
   map_public_ip_on_launch = each.value.public ? true : false
@@ -71,6 +74,7 @@ resource "aws_subnet" "default" {
 resource "aws_route_table" "default" {
   for_each = { for subnet in local.vpc_subnets : subnet.key => subnet }
 
+  region = var.region
   vpc_id = aws_vpc.default.id
 
   tags = merge({ "Name" = each.key }, var.tags)
@@ -79,6 +83,7 @@ resource "aws_route_table" "default" {
 resource "aws_route_table_association" "default" {
   for_each = { for subnet in local.vpc_subnets : subnet.key => subnet }
 
+  region         = var.region
   subnet_id      = aws_subnet.default[each.key].id
   route_table_id = aws_route_table.default[each.key].id
 }
@@ -90,6 +95,7 @@ resource "aws_route_table_association" "default" {
 resource "aws_internet_gateway" "default" {
   count = anytrue(var.networks[*].public) ? 1 : 0
 
+  region = var.region
   vpc_id = aws_vpc.default.id
 
   tags = merge({ "Name" = var.name }, var.tags)
@@ -98,6 +104,7 @@ resource "aws_internet_gateway" "default" {
 resource "aws_route" "internet_gateway" {
   for_each = { for subnet in local.vpc_subnets : subnet.key => subnet if subnet.public }
 
+  region                 = var.region
   route_table_id         = aws_route_table.default[each.key].id
   destination_cidr_block = "0.0.0.0/0"
   gateway_id             = aws_internet_gateway.default[0].id
@@ -110,6 +117,7 @@ resource "aws_route" "internet_gateway" {
 resource "aws_eip" "nat_gw" {
   for_each = { for subnet in local.vpc_subnets : subnet.key => subnet if subnet.nat_gw }
 
+  region = var.region
   domain = "vpc"
 
   tags = merge({ "Name" = "nat-gw_${each.key}" }, var.tags)
@@ -118,6 +126,7 @@ resource "aws_eip" "nat_gw" {
 resource "aws_nat_gateway" "public" {
   for_each = { for subnet in local.vpc_subnets : subnet.key => subnet if subnet.nat_gw }
 
+  region        = var.region
   allocation_id = aws_eip.nat_gw[each.key].id
   subnet_id     = aws_subnet.default[each.key].id
 
@@ -132,12 +141,14 @@ resource "aws_default_vpc" "default" {
   #checkov:skip=CKV_AWS_148: "False positive the default VPC is managed by default in the account"
   count = var.manage_default_vpc ? 1 : 0
 
-  tags = merge({ "Name" = "default" }, var.tags)
+  region = var.region
+  tags   = merge({ "Name" = "default" }, var.tags)
 }
 
 resource "aws_default_security_group" "default_vpc" {
   count = var.manage_default_vpc ? 1 : 0
 
+  region = var.region
   vpc_id = aws_default_vpc.default[0].id
 }
 
@@ -148,6 +159,7 @@ resource "aws_default_security_group" "default_vpc" {
 resource "aws_ec2_transit_gateway_vpc_attachment" "default" {
   count = anytrue(var.networks[*].tgw_attachment) ? 1 : 0
 
+  region                                          = var.region
   appliance_mode_support                          = var.transit_gateway_appliance_mode_support ? "enable" : "disable"
   subnet_ids                                      = [for subnet in local.vpc_subnets : aws_subnet.default[subnet.key].id if subnet.tgw_attachment]
   transit_gateway_default_route_table_association = false
@@ -168,6 +180,7 @@ resource "aws_ec2_transit_gateway_vpc_attachment_accepter" "default" {
 
   count = var.transit_gateway_enable_accepter && anytrue(var.networks[*].tgw_attachment) ? 1 : 0
 
+  region                                          = var.region
   transit_gateway_attachment_id                   = aws_ec2_transit_gateway_vpc_attachment.default[count.index].id
   transit_gateway_default_route_table_association = false
   transit_gateway_default_route_table_propagation = false
@@ -179,6 +192,7 @@ resource "aws_ec2_transit_gateway_route_table_association" "default" {
 
   count = anytrue(var.networks[*].tgw_attachment) ? 1 : 0
 
+  region                         = var.region
   transit_gateway_attachment_id  = aws_ec2_transit_gateway_vpc_attachment.default[0].id
   transit_gateway_route_table_id = var.transit_gateway_route_table_association
 
@@ -190,6 +204,7 @@ resource "aws_ec2_transit_gateway_route_table_propagation" "default" {
 
   for_each = anytrue(var.networks[*].tgw_attachment) ? var.transit_gateway_route_table_propagation : {}
 
+  region                         = var.region
   transit_gateway_attachment_id  = aws_ec2_transit_gateway_vpc_attachment.default[0].id
   transit_gateway_route_table_id = each.value
 
@@ -203,6 +218,7 @@ resource "aws_ec2_transit_gateway_route_table_propagation" "default" {
 resource "aws_route53profiles_association" "default" {
   count = var.route53_profiles_association != null ? 1 : 0
 
+  region      = var.region
   name        = var.route53_profiles_association.association_name
   profile_id  = one([for profile in data.aws_route53profiles_profiles.default.profiles : profile.id if profile.name == var.route53_profiles_association.profile_name])
   resource_id = aws_vpc.default.id

--- a/modules/vpc-endpoints/main.tf
+++ b/modules/vpc-endpoints/main.tf
@@ -122,6 +122,7 @@ data "aws_vpc_endpoint_service" "default" {
 resource "aws_vpc_endpoint" "default" {
   for_each = var.endpoints
 
+  region              = var.region
   auto_accept         = each.value.auto_accept
   ip_address_type     = each.value.ip_address_type
   policy              = each.value.policy
@@ -183,7 +184,7 @@ resource "aws_route53_zone" "custom_zone" {
 
   vpc {
     vpc_id     = var.vpc_id
-    vpc_region = try(var.endpoints[each.value.endpoint].service_region, data.aws_region.current.name)
+    vpc_region = try(var.endpoints[each.value.endpoint].service_region, coalesce(var.region, data.aws_region.current.region))
   }
 
   # Prevent the deletion of associated VPCs after the initial creation.

--- a/modules/vpc-endpoints/terraform.tf
+++ b/modules/vpc-endpoints/terraform.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.82"
+      version = ">= 6.0"
     }
   }
 }

--- a/modules/vpc-endpoints/variables.tf
+++ b/modules/vpc-endpoints/variables.tf
@@ -59,6 +59,12 @@ variable "endpoints" {
   }
 }
 
+variable "region" {
+  type        = string
+  default     = null
+  description = "The AWS region where resources will be created; if omitted the default provider region is used"
+}
+
 variable "security_group_ids" {
   type        = list(string)
   default     = []

--- a/terraform.tf
+++ b/terraform.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source                = "hashicorp/aws"
-      version               = ">= 5.82"
+      version               = ">= 6.0"
       configuration_aliases = [aws.transit_gateway_account]
     }
   }

--- a/variables.tf
+++ b/variables.tf
@@ -90,6 +90,12 @@ variable "networks" {
   description = "A list of objects describing requested subnetwork prefixes."
 }
 
+variable "region" {
+  type        = string
+  default     = null
+  description = "The AWS region where resources will be created; if omitted the default provider region is used"
+}
+
 variable "tags" {
   type        = map(string)
   default     = {}


### PR DESCRIPTION
This PR updates the required AWS Provider version to v6.0 and introduces region parameter to allow defining region where the module resources will be deployed without requiring a separate provider configuration.