### PR TITLE
bug: fix route53 profile resource association name

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -7,7 +7,7 @@ This guide walks you through the steps to migrate centralized VPC endpoints to u
 - You must be on **v4.0.0** of this module before starting the migration.
 - A Route53 Profile must already exist in your hub account, shared with the spoke accounts via AWS RAM, and associated with the relevant VPCs (you will need its ID, e.g. `rp-1a1a1a1a1a1`).
 
-## Step 1: Upgrade to v5.0.0
+## Step 1: Upgrade to v5.0.1
 
 v5.0.0 introduces a new `route53_profile_id` variable on the `vpc-endpoints` submodule. When provided, all existing custom DNS zones (both ipv4 and dualstack) created by the submodule will be associated with the specified Route53 Profile.
 

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -5,6 +5,7 @@ This document captures required refactoring on your part when upgrading to a mod
 ## Upgrading to v5.0.0
 
 This is the first step towards centralizing Interface endpoints using Route53 Profiles. Follow-up changes will be introduced in subsequent releases.
+See the [migration guide](MIGRATION.md) for detailed instructions on how to migrate your existing centralized endpoints to use Route53 Profiles.
 
 ### Key Changes v5.0.0
 

--- a/modules/vpc-endpoints/main.tf
+++ b/modules/vpc-endpoints/main.tf
@@ -224,7 +224,7 @@ resource "aws_route53profiles_resource_association" "custom_zone_association" {
   for_each = local.custom_dns_zones
 
   region       = var.region
-  name         = aws_route53_zone.custom_zone[each.key].name
+  name         = substr(replace(aws_route53_zone.custom_zone[each.key].name, "/[^a-zA-Z0-9\\-_ ]/", "-"), 0, 64)
   profile_id   = var.route53_profile_id
   resource_arn = aws_route53_zone.custom_zone[each.key].arn
 }


### PR DESCRIPTION
Route53 profile resource association name has following constraints - 
Length Constraints: Minimum length of 0. Maximum length of 64.
Pattern: (?!^[0-9]+$)([a-zA-Z0-9\-_' ']+)

This PR replaces invalid characters with "-" and strips the name to 64 characters