### PR TITLE
feat: disassociate hub vpc from the custom dns zones

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -5,11 +5,11 @@ This guide walks you through the steps to migrate centralized VPC endpoints to u
 ## Prerequisites
 
 - You must be on **v4.0.0** of this module before starting the migration.
-- A Route53 Profile must already exist in your hub account, shared with the spoke accounts via AWS RAM, and associated with the relevant VPCs (you will need its ID, e.g. `rp-1a1a1a1a1a1`).
+- A Route53 Profile must already exist in your hub account, shared with the spoke accounts via AWS RAM, and associated with the relevant VPCs (you will need its ID, e.g. `rp-1a1a1a1a1a`).
 
-## Step 1: Upgrade to v5.0.1
+## Step 1: Upgrade to v5.1.0
 
-v5.0.0 introduces a new `route53_profile_id` variable on the `vpc-endpoints` submodule. When provided, all existing custom DNS zones (both ipv4 and dualstack) created by the submodule will be associated with the specified Route53 Profile.
+v5.1.0 introduces a new `route53_profile_id` variable on the `vpc-endpoints` submodule. When provided, all existing custom DNS zones (both ipv4 and dualstack) created by the submodule will be associated with the specified Route53 Profile and removes the hub VPC association with custom DNS zones for centralized endpoints. DNS resolution continues functioning because the hub VPC remains associated with the Route 53 Profile, which maintains its connection to the custom DNS zones.
 
 ### Update the module version and add `route53_profile_id` to the `vpc-endpoints` submodule
 
@@ -23,3 +23,84 @@ module "vpc_endpoints" {
   # ...existing configuration...
 }
 ```
+
+### 1.1: Disassociate the hub VPC from all custom zones
+
+Since the `aws_route53_zone` resource has `ignore_changes = [vpc]`, Terraform cannot remove the inline VPC association.
+
+> **⚠️ IMPORTANT: You must disassociate the hub VPC manually using the AWS CLI only after upgrading to v5.1.0 and applying the changes.**
+
+Use the following script to list all private hosted zones associated with the hub VPC and disassociate them. The script filters zones by a name pattern to ensure only the relevant endpoint zones are targeted.
+
+```bash
+#!/bin/bash
+# Usage: ./disassociate_vpc.sh <vpc_id> <vpc_region> <aws_profile>
+# Example: ./disassociate_vpc.sh vpc-0abc123def456 eu-central-1 my-aws-profile
+#
+# This script lists all private hosted zones associated with the hub VPC
+# and disassociates only VPC endpoint zones (zones ending in .amazonaws.com. or .api.aws.).
+
+set -euo pipefail
+
+export AWS_PAGER=""
+
+VPC_ID="${1:?Usage: $0 <vpc_id> <vpc_region> <aws_profile>}"
+VPC_REGION="${2:?Provide VPC region}"
+AWS_PROFILE="${3:?Provide AWS profile name}"
+
+echo "Listing all private hosted zones associated with VPC ${VPC_ID} in ${VPC_REGION}..."
+
+ZONES=$(aws route53 list-hosted-zones-by-vpc \
+  --vpc-id "${VPC_ID}" \
+  --vpc-region "${VPC_REGION}" \
+  --query 'HostedZoneSummaries[*].[HostedZoneId,Name]' \
+  --output text \
+  --profile "${AWS_PROFILE}")
+
+if [ -z "${ZONES}" ]; then
+  echo "No hosted zones found for VPC ${VPC_ID}."
+  exit 0
+fi
+
+echo "${ZONES}" | while read -r ZONE_ID ZONE_NAME; do
+  # Only target VPC endpoint zones (ending in .amazonaws.com. or .api.aws.)
+  if ! echo "${ZONE_NAME}" | grep -qE '\.(amazonaws\.com|api\.aws)\.$'; then
+    echo "Skipping zone ${ZONE_NAME} (${ZONE_ID}) - not a VPC endpoint zone"
+    continue
+  fi
+
+  echo "Disassociating VPC ${VPC_ID} from zone ${ZONE_NAME} (${ZONE_ID})..."
+
+  aws route53 disassociate-vpc-from-hosted-zone \
+    --hosted-zone-id "${ZONE_ID}" \
+    --vpc "VPCRegion=${VPC_REGION},VPCId=${VPC_ID}" \
+    --comment "Migration: removing inline VPC association" \
+    --profile "${AWS_PROFILE}" \
+    && echo "  ✓ Successfully disassociated" \
+    || echo "  ✗ Failed (may already be disassociated)"
+done
+
+echo "Done."
+```
+
+Run the script:
+
+```bash
+chmod +x disassociate_vpc.sh
+./disassociate_vpc.sh vpc-0abc123def456 eu-central-1 my-aws-profile
+```
+
+### 1.2: Verify all VPC endpoint zones have been disassociated
+
+After running the script, verify that no VPC endpoint zones remain associated with the hub VPC:
+
+```bash
+aws route53 list-hosted-zones-by-vpc \
+  --vpc-id vpc-0abc123def456 \
+  --vpc-region eu-central-1 \
+  --profile my-aws-profile \
+  --query 'HostedZoneSummaries[?ends_with(Name, `.amazonaws.com.`) || ends_with(Name, `.api.aws.`)].[HostedZoneId,Name]' \
+  --output table
+```
+
+If the output is empty, all VPC endpoint zones have been successfully disassociated. If you still see associations, you can safely re-run the disassociation script it is idempotent and will skip zones that are already disassociated.

--- a/modules/vpc-endpoints/main.tf
+++ b/modules/vpc-endpoints/main.tf
@@ -182,11 +182,6 @@ resource "aws_route53_zone" "custom_zone" {
   force_destroy = false
   tags          = var.tags
 
-  vpc {
-    vpc_id     = var.vpc_id
-    vpc_region = try(var.endpoints[each.value.endpoint].service_region, coalesce(var.region, data.aws_region.current.region))
-  }
-
   # Prevent the deletion of associated VPCs after the initial creation.
   # See documentation on aws_route53_zone_association for details.
   lifecycle {


### PR DESCRIPTION
This pull request updates the migration guide and Terraform module to support v5.1.0, which changes how custom DNS zone associations are managed for centralized VPC endpoints. The main change is the removal of hub VPC associations with custom Route 53 zones, requiring a manual disassociation step before upgrading. The documentation now includes a script to help with this process, and the Terraform resource for associating VPCs with Route 53 zones has been updated accordingly.

**Migration process and documentation updates:**

* Added a new migration step for upgrading to v5.1.0 in `MIGRATION.md`, explaining that hub VPC associations with custom DNS zones are removed, and DNS resolution will continue via the Route 53 Profile.
* Included a Bash script in `MIGRATION.md` to help users list and disassociate the hub VPC from all relevant private hosted zones before upgrading, since Terraform cannot remove these associations automatically.

**Terraform module changes:**

* Removed the inline `vpc` block from the `aws_route53_zone.custom_zone` resource in `modules/vpc-endpoints/main.tf`, reflecting the new approach to managing VPC associations.

**Other documentation adjustments:**

* Minor text formatting correction in the prerequisites section of `MIGRATION.md`.