### PR TITLE
feat: enable private dns for centralized interface endpoints

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -104,3 +104,8 @@ aws route53 list-hosted-zones-by-vpc \
 ```
 
 If the output is empty, all VPC endpoint zones have been successfully disassociated. If you still see associations, you can safely re-run the disassociation script it is idempotent and will skip zones that are already disassociated.
+
+
+## Step 2: Upgrade to v5.2.0
+
+v5.2.0 enables private DNS for all centralized endpoints by default, which is a requirement for using Route53 Profiles. After upgrading, the hub vpc dns resolves through its AWS-managed private hosted zone (which runs in the background) while spoke vpcs continue DNS resolution through direct association with self-managed private hosted zones.

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -4,20 +4,11 @@ This document captures required refactoring on your part when upgrading to a mod
 
 ## Upgrading to v5.0.0
 
-This is the first step towards centralizing Interface endpoints using Route53 Profiles. Follow-up changes will be introduced in subsequent releases.
+> **⚠️ WARNING: You must strictly follow the [migration guide](MIGRATION.md) and upgrade through each minor version (v5.0.0 → v5.1.0 → v5.2.0) in order. Skipping versions may result in DNS resolution failures. Do not jump directly to the latest v5.x release.**
+
+v5.0 provides a migration path for centralizing Interface endpoints using Route53 Profiles. The migration is split across multiple minor releases and must be followed in order.
+
 See the [migration guide](MIGRATION.md) for detailed instructions on how to migrate your existing centralized endpoints to use Route53 Profiles.
-
-### Key Changes v5.0.0
-
-### VPC Endpoints submodule
-
-#### New variable: `route53_profile_id`
-
-A new variable `route53_profile_id` has been added to the `vpc-endpoints` submodule. This variable is **required** when any endpoint has `centralized_endpoint` set to `true`. It accepts the Route53 Profile ID used for associating custom DNS zones.
-
-All custom DNS zones created by the submodule (both ipv4 and dualstack) are now automatically associated with the specified Route53 Profile via `aws_route53profiles_resource_association`.
-
-If none of your endpoints use `centralized_endpoint = true`, `route53_profile_id` can remain unset (`null`).
 
 
 ## Upgrading to v4.0.0

--- a/modules/vpc-endpoints/main.tf
+++ b/modules/vpc-endpoints/main.tf
@@ -7,11 +7,16 @@ locals {
     key => coalesce(endpoint.service_full_name, try(data.aws_vpc_endpoint_service.default[key].service_name, null))
   }
 
-  # Private DNS is disabled for centralized endpoints, endpoints with a custom privatelink dns_zone, or non-Interface endpoint types.
+  # Private DNS is disabled for non-Interface endpoint types and when a custom privatelink dns zone is specified.
+  # For centralized Interface endpoints (without a custom dns_zone), it is enabled.
   # Otherwise, it uses the value from `private_dns_enabled` for the endpoint.
   private_dns_enabled = {
     for key, endpoint in var.endpoints :
-    key => (endpoint.centralized_endpoint || try(endpoint.private_link_dns_options.dns_zone != null, false) || endpoint.type != "Interface") ? false : endpoint.private_dns_enabled
+    key => endpoint.type != "Interface" ? false : (
+      try(endpoint.private_link_dns_options.dns_zone, null) != null ? false : (
+        endpoint.centralized_endpoint ? true : endpoint.private_dns_enabled
+      )
+    )
   }
 
   ## Custom DNS Zone & Records


### PR DESCRIPTION
This pull request updates the behavior of private DNS enablement for VPC endpoints and documents the changes required for upgrading to version 5.2.0. The main focus is on enabling private DNS by default for centralized Interface endpoints, which is necessary for Route53 Profiles support.

**Private DNS logic changes:**

* Updated the logic in `modules/vpc-endpoints/main.tf` to enable private DNS by default for centralized Interface endpoints (unless a custom DNS zone is specified), while keeping it disabled for non-Interface endpoint types and when a custom DNS zone is provided.

**Documentation updates:**

* Added a new upgrade step in `MIGRATION.md` describing the changes in v5.2.0, specifically the default enablement of private DNS for centralized endpoints and its impact on DNS resolution for hub and spoke VPCs.