### PR TITLE
feat: conditionally remove private hosted zone associations with rout…

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -106,6 +106,13 @@ aws route53 list-hosted-zones-by-vpc \
 If the output is empty, all VPC endpoint zones have been successfully disassociated. If you still see associations, you can safely re-run the disassociation script it is idempotent and will skip zones that are already disassociated.
 
 
-## Step 2: Upgrade to v5.2.0
+## Step 2: Upgrade to v5.2.1
 
-v5.2.0 enables private DNS for all centralized endpoints by default, which is a requirement for using Route53 Profiles. After upgrading, the hub vpc dns resolves through its AWS-managed private hosted zone (which runs in the background) while spoke vpcs continue DNS resolution through direct association with self-managed private hosted zones.
+v5.2.1 enables private DNS for all centralized endpoints by default, which is a requirement for using Route53 Profiles. After upgrading, the hub vpc dns resolves through its AWS-managed private hosted zone (which runs in the background) while spoke vpcs continue DNS resolution through direct association with self-managed private hosted zones.
+
+
+## Step 3: Upgrade to v5.3.0
+
+v5.3.0 disassociates the custom DNS zones for centralized endpoints from the Route53 Profile. DNS resolution continues functioning because the spoke VPCs remain associated with the custom DNS zones through direct VPC association.
+
+> **Note:** Custom DNS zones for DynamoDB endpoints and endpoints with `private_link_dns_options.dns_zone` configured remain associated with the Route53 Profile. These endpoints do not support private DNS, so the Route53 Profile association is still required for DNS resolution in spoke VPCs.

--- a/modules/vpc-endpoints/main.tf
+++ b/modules/vpc-endpoints/main.tf
@@ -224,7 +224,11 @@ resource "aws_route53_record" "custom_dns_record" {
 ########################################################################
 
 resource "aws_route53profiles_resource_association" "custom_zone_association" {
-  for_each = local.custom_dns_zones
+  for_each = {
+    for key, zone in local.custom_dns_zones :
+    key => zone if try(var.endpoints[zone.endpoint].private_link_dns_options.dns_zone, null) != null ||
+    can(regex("dynamodb", local.real_service_names[zone.endpoint]))
+  }
 
   region       = var.region
   name         = substr(replace(aws_route53_zone.custom_zone[each.key].name, "/[^a-zA-Z0-9\\-_ ]/", "-"), 0, 64)


### PR DESCRIPTION
This pull request introduces updates related to how custom DNS zones are associated with Route53 Profiles in the VPC endpoints module, and documents these changes in the migration guide. The main focus is to ensure that only the necessary DNS zones remain associated with Route53 Profiles, improving DNS management and clarity for future upgrades.

**Migration and DNS association changes:**

* Updated the migration guide (`MIGRATION.md`) to add instructions for upgrading to v5.3.0, clarifying that custom DNS zones for centralized endpoints are now disassociated from the Route53 Profile, except for DynamoDB endpoints and endpoints with `private_link_dns_options.dns_zone` set.

* Modified the Route53 Profile association logic in `modules/vpc-endpoints/main.tf` so that only custom DNS zones for DynamoDB endpoints or those explicitly configured with `private_link_dns_options.dns_zone` remain associated with the Route53 Profile. All other custom DNS zones are now excluded from this association.