### PR TITLE
feat: associate interface endpoints with route53 profile

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -116,3 +116,10 @@ v5.2.1 enables private DNS for all centralized endpoints by default, which is a 
 v5.3.0 disassociates the custom DNS zones for centralized endpoints from the Route53 Profile. DNS resolution continues functioning because the spoke VPCs remain associated with the custom DNS zones through direct VPC association.
 
 > **Note:** Custom DNS zones for DynamoDB endpoints and endpoints with `private_link_dns_options.dns_zone` configured remain associated with the Route53 Profile. These endpoints do not support private DNS, so the Route53 Profile association is still required for DNS resolution in spoke VPCs.
+
+
+## Step 4: Upgrade to v5.4.0
+
+v5.4.0 associates centralised interface endpoints with Route53 profile.
+
+> **Note:** Interface endpoints with `private_link_dns_options.dns_zone` configured and DynamoDB endpoints are not associated with the Route53 Profile. These endpoints rely on custom DNS zones which remain associated with the Route53 Profile.

--- a/modules/vpc-endpoints/README.md
+++ b/modules/vpc-endpoints/README.md
@@ -50,6 +50,7 @@ No modules.
 | [aws_route53_record.custom_dns_record](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
 | [aws_route53_zone.custom_zone](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_zone) | resource |
 | [aws_route53profiles_resource_association.custom_zone_association](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53profiles_resource_association) | resource |
+| [aws_route53profiles_resource_association.interface_endpoint_association](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53profiles_resource_association) | resource |
 | [aws_vpc_endpoint.default](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/vpc_endpoint) | resource |
 | [aws_region.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/region) | data source |
 | [aws_vpc_endpoint_service.default](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/vpc_endpoint_service) | data source |

--- a/modules/vpc-endpoints/main.tf
+++ b/modules/vpc-endpoints/main.tf
@@ -235,3 +235,15 @@ resource "aws_route53profiles_resource_association" "custom_zone_association" {
   profile_id   = var.route53_profile_id
   resource_arn = aws_route53_zone.custom_zone[each.key].arn
 }
+
+resource "aws_route53profiles_resource_association" "interface_endpoint_association" {
+  for_each = {
+    for key, endpoint in var.endpoints :
+    key => endpoint if endpoint.type == "Interface" && try(endpoint.private_link_dns_options.dns_zone, null) == null && endpoint.centralized_endpoint && !can(regex("dynamodb", local.real_service_names[key]))
+  }
+
+  region       = var.region
+  name         = substr(replace(each.key, "/[^a-zA-Z0-9\\-_ ]/", "-"), 0, 64)
+  profile_id   = var.route53_profile_id
+  resource_arn = aws_vpc_endpoint.default[each.key].arn
+}


### PR DESCRIPTION
This pull request introduces an update to associate centralized interface VPC endpoints with the Route53 Profile, while explicitly excluding endpoints that use custom DNS zones or are DynamoDB endpoints. This change ensures that DNS resolution for centralized interface endpoints is managed via the Route53 Profile, improving DNS management consistency, while maintaining the existing behavior for endpoints that require custom DNS zones.

**Updates to DNS association logic:**

* Added a new `aws_route53profiles_resource_association` resource in `modules/vpc-endpoints/main.tf` to associate centralized interface endpoints (excluding those with custom DNS zones or DynamoDB endpoints) with the Route53 Profile.

**Documentation updates:**

* Updated `MIGRATION.md` to document the new association behavior in v5.4.0, clarifying which endpoints are associated with the Route53 Profile and which continue to rely on custom DNS zones.