### PR TITLE
feat: remove redundant custom zones

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -24,13 +24,13 @@ module "vpc_endpoints" {
 }
 ```
 
-### 1.1: Disassociate the hub VPC from all custom zones
+### 1.1: Disassociate the hub VPC from all custom zones (excluding DynamoDB)
 
 Since the `aws_route53_zone` resource has `ignore_changes = [vpc]`, Terraform cannot remove the inline VPC association.
 
 > **⚠️ IMPORTANT: You must disassociate the hub VPC manually using the AWS CLI only after upgrading to v5.1.0 and applying the changes.**
 
-Use the following script to list all private hosted zones associated with the hub VPC and disassociate them. The script filters zones by a name pattern to ensure only the relevant endpoint zones are targeted.
+Use the following script to list all private hosted zones associated with the hub VPC and disassociate them. The script filters zones by a name pattern to ensure only the relevant endpoint zones are targeted, and excludes DynamoDB zones (which must remain associated with the VPC).
 
 ```bash
 #!/bin/bash
@@ -38,7 +38,8 @@ Use the following script to list all private hosted zones associated with the hu
 # Example: ./disassociate_vpc.sh vpc-0abc123def456 eu-central-1 my-aws-profile
 #
 # This script lists all private hosted zones associated with the hub VPC
-# and disassociates only VPC endpoint zones (zones ending in .amazonaws.com. or .api.aws.).
+# and disassociates only VPC endpoint zones (zones ending in .amazonaws.com. or .api.aws.),
+# excluding DynamoDB zones.
 
 set -euo pipefail
 
@@ -66,6 +67,12 @@ echo "${ZONES}" | while read -r ZONE_ID ZONE_NAME; do
   # Only target VPC endpoint zones (ending in .amazonaws.com. or .api.aws.)
   if ! echo "${ZONE_NAME}" | grep -qE '\.(amazonaws\.com|api\.aws)\.$'; then
     echo "Skipping zone ${ZONE_NAME} (${ZONE_ID}) - not a VPC endpoint zone"
+    continue
+  fi
+
+  # Skip DynamoDB zones (they must remain associated with the VPC)
+  if echo "${ZONE_NAME}" | grep -qi 'dynamodb'; then
+    echo "Skipping zone ${ZONE_NAME} (${ZONE_ID}) - DynamoDB zone must remain associated"
     continue
   fi
 
@@ -103,7 +110,11 @@ aws route53 list-hosted-zones-by-vpc \
   --output table
 ```
 
-If the output is empty, all VPC endpoint zones have been successfully disassociated. If you still see associations, you can safely re-run the disassociation script it is idempotent and will skip zones that are already disassociated.
+If the output is empty, all VPC endpoint zones have been successfully disassociated. If you still see associations, you can safely re-run the disassociation script—it is idempotent and will skip zones that are already disassociated.
+
+> **Why might you need to run the script again?**
+>
+> AWS Route 53 may take some time to process disassociation requests, especially if you have a large number of hosted zones. If you run the verification command immediately after the script, some associations may still appear as pending removal. Wait a few minutes and re-run the script if needed. The script is safe to run multiple times and will only attempt to disassociate zones that are still associated with the VPC.
 
 
 ## Step 2: Upgrade to v5.2.1
@@ -123,3 +134,18 @@ v5.3.0 disassociates the custom DNS zones for centralized endpoints from the Rou
 v5.4.0 associates centralised interface endpoints with Route53 profile.
 
 > **Note:** Interface endpoints with `private_link_dns_options.dns_zone` configured and DynamoDB endpoints are not associated with the Route53 Profile. These endpoints rely on custom DNS zones which remain associated with the Route53 Profile.
+
+
+## Step 5: Upgrade to v5.5.0
+
+v5.5.0 removes all redundant custom DNS zones for centralized endpoints. DNS resolution for interface vpc endpoints is now fully handled by the Route53 Profile.
+
+> **⚠️ IMPORTANT: You must complete Step 5.1 before upgrading the module in Step 5.2.**
+
+### 5.1: Remove spoke VPC associations from custom DNS zones
+
+Before upgrading, you must remove all spoke VPC direct associations with the custom DNS zones. However, you must keep **one** VPC association per zone, since Route53 private hosted zones must be associated with at least one VPC to exist.
+
+### 5.2: Upgrade to v5.5.0
+
+After completing Step 5.1, upgrade the module to v5.5.0. This version deletes all redundant custom DNS zones. When a zone is deleted, the remaining VPC association (kept in Step 5.1) is automatically removed along with it.

--- a/modules/vpc-endpoints/main.tf
+++ b/modules/vpc-endpoints/main.tf
@@ -26,39 +26,43 @@ locals {
 
   # Computes the ipv4 DNS zone name for each endpoint, either derived from the service name or explicitly provided.
   # If it's derived from the service name then we reverse the service name
-  # (e.g., `com.amazonaws.eu-central-1.sts` becomes `sts.eu-central-1.amazonaws.com`).
+  # (e.g., `com.amazonaws.eu-central-1.dynamodb` becomes `dynamodb.eu-central-1.amazonaws.com`).
+  # Only computed for endpoints with a privatelink `dns_zone` explicitly provided or DynamoDB endpoints.
   custom_ipv4_zones_names = {
     for key, endpoint in var.endpoints :
     key => try(endpoint.private_link_dns_options.dns_zone, null) != null ? endpoint.private_link_dns_options.dns_zone : join(".", reverse(split(".", local.real_service_names[key])))
+    if try(endpoint.private_link_dns_options.dns_zone, null) != null || can(regex("dynamodb", local.real_service_names[key]))
   }
 
   # Computes the dualstack DNS zone for each endpoint, derived from the service name.
-  # (e.g., `com.amazonaws.eu-central-1.sts` becomes `sts.eu-central-1.api.aws`).
+  # (e.g., `com.amazonaws.eu-central-1.dynamodb` becomes `dynamodb.eu-central-1.api.aws`).
+  # Only computed for DynamoDB endpoints.
   custom_dualstack_zones_names = {
     for key, endpoint in var.endpoints :
-    key => try(endpoint.private_link_dns_options.dns_zone, null) != null ? null : join(".", concat(
+    key => join(".", concat(
       reverse(slice(split(".", local.real_service_names[key]), 2, length(split(".", local.real_service_names[key])))),
       ["api", "aws"]
     ))
+    if can(regex("dynamodb", local.real_service_names[key]))
   }
 
   # A unified map of all custom DNS zones to create, combining both the ipv4 and dualstack zones.
-  # A custom DNS zone is created if the endpoint is centralized or if the privatelink `dns_zone` is explicitly provided.
-  # Each entry is keyed as "<endpoint_key>" for the ipv4 zone and "<endpoint_key>-dualstack" for the dualstack zone.
+  # An ipv4 custom DNS zone is created if the endpoint has a privatelink `dns_zone` explicitly provided or is a DynamoDB endpoint.
+  # A dualstack custom DNS zone is created only for DynamoDB endpoints.
   custom_dns_zones = merge(
     {
-      for key, endpoint in var.endpoints :
+      for key, zone_name in local.custom_ipv4_zones_names :
       key => {
         endpoint  = key
-        zone_name = local.custom_ipv4_zones_names[key]
-      } if endpoint.centralized_endpoint || try(endpoint.private_link_dns_options.dns_zone, null) != null
+        zone_name = zone_name
+      }
     },
     {
-      for key, endpoint in var.endpoints :
+      for key, zone_name in local.custom_dualstack_zones_names :
       "${key}-dualstack" => {
         endpoint  = key
-        zone_name = local.custom_dualstack_zones_names[key]
-      } if endpoint.centralized_endpoint && local.custom_dualstack_zones_names[key] != null
+        zone_name = zone_name
+      }
     }
   )
 
@@ -66,8 +70,8 @@ locals {
   custom_records = flatten([
     for key, endpoint in var.endpoints :
 
-    # 1) CENTRALIZED => If `centralized_endpoint = true` AND no custom dns_zone. Create alias apex + wildcard record.
-    endpoint.centralized_endpoint && try(endpoint.private_link_dns_options.dns_zone, null) == null ? [
+    # 1) CENTRALIZED DYNAMODB => If `centralized_endpoint = true` AND no custom dns_zone AND is a DynamoDB endpoint. Create alias apex + wildcard record.
+    endpoint.centralized_endpoint && try(endpoint.private_link_dns_options.dns_zone, null) == null && can(regex("dynamodb", local.real_service_names[key])) ? [
       {
         alias       = true
         endpoint    = key
@@ -190,7 +194,11 @@ resource "aws_route53_zone" "custom_zone" {
   force_destroy = false
   tags          = var.tags
 
-  # Prevent the deletion of associated VPCs after the initial creation.
+  vpc {
+    vpc_id = var.vpc_id
+  }
+
+  # Prevent the deletion of additional VPC associations managed outside this module.
   # See documentation on aws_route53_zone_association for details.
   lifecycle {
     ignore_changes = [vpc]
@@ -224,11 +232,7 @@ resource "aws_route53_record" "custom_dns_record" {
 ########################################################################
 
 resource "aws_route53profiles_resource_association" "custom_zone_association" {
-  for_each = {
-    for key, zone in local.custom_dns_zones :
-    key => zone if try(var.endpoints[zone.endpoint].private_link_dns_options.dns_zone, null) != null ||
-    can(regex("dynamodb", local.real_service_names[zone.endpoint]))
-  }
+  for_each = local.custom_dns_zones
 
   region       = var.region
   name         = substr(replace(aws_route53_zone.custom_zone[each.key].name, "/[^a-zA-Z0-9\\-_ ]/", "-"), 0, 64)


### PR DESCRIPTION
This pull request updates the VPC Endpoints module to refine the handling of custom DNS zones, especially for DynamoDB endpoints, and introduces new migration steps for upgrading to v5.5.0. The changes clarify and enforce the correct association and disassociation of DNS zones, ensuring that DynamoDB zones remain properly associated while redundant custom zones are removed in later versions. The documentation and Terraform logic are updated to reflect these improvements.

**Migration and upgrade process improvements:**

* The migration guide now explicitly states that DynamoDB zones must remain associated with the hub VPC during disassociation, and the provided script is updated to skip DynamoDB zones. Additional guidance is added about AWS propagation delays and safe script re-runs. [[1]](diffhunk://#diff-c1603ee6a674bb75255aa448057630506153e363297fd58668e6679f10909bc6L27-R42) [[2]](diffhunk://#diff-c1603ee6a674bb75255aa448057630506153e363297fd58668e6679f10909bc6R73-R78) [[3]](diffhunk://#diff-c1603ee6a674bb75255aa448057630506153e363297fd58668e6679f10909bc6L106-R117)
* New documentation for upgrading to v5.5.0 is added, instructing users to remove spoke VPC associations from custom DNS zones before upgrading, and clarifying that only one VPC association per zone should remain to allow for zone deletion.

**Terraform logic changes for DNS zone creation and association:**

* The logic for computing `custom_ipv4_zones_names` and `custom_dualstack_zones_names` is updated to ensure that only endpoints with an explicit `dns_zone` or DynamoDB endpoints are included, and that dualstack zones are only created for DynamoDB. The `custom_dns_zones` map is correspondingly updated to reflect these rules.
* The `aws_route53_zone` resource now always associates the primary VPC (`vpc_id`) with the custom zone, ensuring at least one association is present as required by Route53.
* The `aws_route53profiles_resource_association` resource is simplified to iterate directly over `local.custom_dns_zones`, reflecting the new logic for zone creation and association.