### PR TITLE
bug: create custom zones only for centralized interface endpoints

### DIFF
--- a/modules/vpc-endpoints/main.tf
+++ b/modules/vpc-endpoints/main.tf
@@ -31,7 +31,7 @@ locals {
   custom_ipv4_zones_names = {
     for key, endpoint in var.endpoints :
     key => try(endpoint.private_link_dns_options.dns_zone, null) != null ? endpoint.private_link_dns_options.dns_zone : join(".", reverse(split(".", local.real_service_names[key])))
-    if try(endpoint.private_link_dns_options.dns_zone, null) != null || can(regex("dynamodb", local.real_service_names[key]))
+    if try(endpoint.private_link_dns_options.dns_zone, null) != null || (endpoint.type == "Interface" && endpoint.centralized_endpoint && can(regex("dynamodb", local.real_service_names[key])))
   }
 
   # Computes the dualstack DNS zone for each endpoint, derived from the service name.
@@ -43,7 +43,7 @@ locals {
       reverse(slice(split(".", local.real_service_names[key]), 2, length(split(".", local.real_service_names[key])))),
       ["api", "aws"]
     ))
-    if can(regex("dynamodb", local.real_service_names[key]))
+    if endpoint.type == "Interface" && endpoint.centralized_endpoint && can(regex("dynamodb", local.real_service_names[key]))
   }
 
   # A unified map of all custom DNS zones to create, combining both the ipv4 and dualstack zones.


### PR DESCRIPTION
This pull request makes targeted adjustments to the logic that determines when custom DNS zones are created for DynamoDB VPC endpoints. The changes add stricter conditions, ensuring that custom DNS zones for DynamoDB are only created for "Interface" type endpoints that are also centralized. This helps prevent the unnecessary creation of DNS zones in other scenarios.

Changes to custom DNS zone creation logic:

* Updated the condition in the `custom_ipv4_zones_names` local variable to only include DynamoDB endpoints if they are of type "Interface" and are centralized.
* Modified the logic for dualstack DNS zone computation to similarly restrict custom DNS zone creation to centralized "Interface" type DynamoDB endpoints.