### PR TITLE
feat: add vpc_endpoints variable to root module for creating VPC endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ This module will be merged with the [terraform-aws-mcaf-vpc](https://github.com/
 | Name | Source | Version |
 |------|--------|---------|
 | <a name="module_log_bucket"></a> [log\_bucket](#module\_log\_bucket) | schubergphilis/mcaf-s3/aws | ~> 2.0.0 |
+| <a name="module_vpc_endpoints"></a> [vpc\_endpoints](#module\_vpc\_endpoints) | ./modules/vpc-endpoints | n/a |
 
 ## Resources
 
@@ -58,9 +59,11 @@ This module will be merged with the [terraform-aws-mcaf-vpc](https://github.com/
 | [aws_route53profiles_association.default](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53profiles_association) | resource |
 | [aws_route_table.default](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route_table) | resource |
 | [aws_route_table_association.default](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route_table_association) | resource |
+| [aws_security_group.vpc_endpoints](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group) | resource |
 | [aws_subnet.default](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/subnet) | resource |
 | [aws_vpc.default](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/vpc) | resource |
 | [aws_vpc_ipam_preview_next_cidr.vpc](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/vpc_ipam_preview_next_cidr) | resource |
+| [aws_vpc_security_group_ingress_rule.vpc_endpoints](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/vpc_security_group_ingress_rule) | resource |
 | [aws_caller_identity.default](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
 | [aws_iam_policy_document.vpc_flow_log](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.vpc_flow_logs_assume_role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
@@ -87,6 +90,7 @@ This module will be merged with the [terraform-aws-mcaf-vpc](https://github.com/
 | <a name="input_transit_gateway_route_table_association"></a> [transit\_gateway\_route\_table\_association](#input\_transit\_gateway\_route\_table\_association) | Transit Gateway route table ID to attach the VPC on. | `string` | `""` | no |
 | <a name="input_transit_gateway_route_table_propagation"></a> [transit\_gateway\_route\_table\_propagation](#input\_transit\_gateway\_route\_table\_propagation) | Map of [logical name]→[Transit Gateway route table ID] to propagate the VPC CIDR to. | `map(string)` | `{}` | no |
 | <a name="input_vpc_cidr_netmask"></a> [vpc\_cidr\_netmask](#input\_vpc\_cidr\_netmask) | The netmask length of the IPv4 CIDR you want to allocate to this VPC. | `number` | `20` | no |
+| <a name="input_vpc_endpoints"></a> [vpc\_endpoints](#input\_vpc\_endpoints) | Configuration for VPC endpoints. When provided, the vpc-endpoints submodule is invoked automatically with the VPC ID, region, and Route53 profile ID derived from the root module. Gateway endpoints will automatically use the private subnet route table IDs, and Interface/GatewayLoadBalancer endpoints will automatically use the private subnet IDs. | <pre>object({<br/>    endpoints = optional(map(object({<br/>      auto_accept          = optional(bool)<br/>      ip_address_type      = optional(string)<br/>      policy               = optional(string)<br/>      private_dns_enabled  = optional(bool, true)<br/>      centralized_endpoint = optional(bool, false)<br/>      security_group_ids   = optional(list(string), [])<br/>      service              = optional(string)<br/>      service_full_name    = optional(string)<br/>      service_region       = optional(string)<br/>      type                 = optional(string, "Interface")<br/><br/>      dns_options = optional(object({<br/>        dns_record_ip_type                             = optional(string)<br/>        private_dns_only_for_inbound_resolver_endpoint = optional(bool)<br/>      }))<br/><br/>      private_link_dns_options = optional(object({<br/>        dns_record_ttl  = optional(number, 300)<br/>        dns_record_type = optional(string, "CNAME")<br/>        dns_records     = optional(list(string), [])<br/>        dns_zone        = string<br/>      }))<br/>    })), {})<br/><br/>    security_group_ids = optional(list(string), [])<br/>  })</pre> | `null` | no |
 
 ## Outputs
 

--- a/main.tf
+++ b/main.tf
@@ -225,3 +225,50 @@ resource "aws_route53profiles_association" "default" {
 
   tags = var.tags
 }
+
+################################################################################
+# VPC Endpoints
+################################################################################
+
+module "vpc_endpoints" {
+  source = "./modules/vpc-endpoints"
+
+  count = var.vpc_endpoints != null ? 1 : 0
+
+  region             = var.region
+  route53_profile_id = anytrue([for endpoint in values(var.vpc_endpoints.endpoints) : endpoint.centralized_endpoint]) && var.route53_profiles_association != null ? var.route53_profiles_association.profile_id : null
+  security_group_ids = length(var.vpc_endpoints.security_group_ids) > 0 ? var.vpc_endpoints.security_group_ids : [aws_security_group.vpc_endpoints[0].id]
+  tags               = var.tags
+  vpc_id             = aws_vpc.default.id
+
+  endpoints = {
+    for key, endpoint in var.vpc_endpoints.endpoints :
+    key => merge(endpoint, {
+      route_table_ids = endpoint.type == "Gateway" ? flatten([for network in var.networks : [for az in var.availability_zones : aws_route_table.default["${network.name}_${az}"].id] if !network.public]) : null
+      subnet_ids      = contains(["Interface", "GatewayLoadBalancer"], endpoint.type) ? flatten([for network in var.networks : [for az in var.availability_zones : aws_subnet.default["${network.name}_${az}"].id] if !network.public]) : []
+    })
+  }
+}
+
+resource "aws_security_group" "vpc_endpoints" {
+  count = var.vpc_endpoints != null && length(var.vpc_endpoints.security_group_ids) == 0 ? 1 : 0
+
+  region      = var.region
+  description = "VPC Endpoint Security Group"
+  name_prefix = "vpc-endpoints-"
+  vpc_id      = aws_vpc.default.id
+
+  tags = merge({ "Name" = "vpc-endpoints" }, var.tags)
+}
+
+resource "aws_vpc_security_group_ingress_rule" "vpc_endpoints" {
+  count = var.vpc_endpoints != null && length(var.vpc_endpoints.security_group_ids) == 0 ? 1 : 0
+
+  region            = var.region
+  security_group_id = aws_security_group.vpc_endpoints[0].id
+  cidr_ipv4         = aws_vpc.default.cidr_block
+  description       = "Allow HTTPS access from VPC CIDR block"
+  from_port         = 443
+  to_port           = 443
+  ip_protocol       = "tcp"
+}

--- a/variables.tf
+++ b/variables.tf
@@ -1,17 +1,3 @@
-variable "route53_profiles_association" {
-  type = object({
-    association_name = string
-    profile_id       = string
-  })
-  default     = null
-  description = "Variable to enable Route53 Profile association. Specify the 'profile_id' of a Route53 Profile in the account to associate with the VPC, and an arbitrary 'association_name'. Note: AWS only supports one Route53 Profile per VPC."
-
-  validation {
-    condition     = var.route53_profiles_association == null ? true : (can(regex("^[a-zA-Z0-9\\-_ ']+$", var.route53_profiles_association.association_name)) && !can(regex("^[0-9]+$", var.route53_profiles_association.association_name)))
-    error_message = "association_name must match (?!^[0-9]+$)([a-zA-Z0-9\\-_ ']+) (not purely numeric)."
-  }
-}
-
 variable "availability_zones" {
   type        = list(string)
   description = "A list of availability zones names or ids in the region."
@@ -20,33 +6,6 @@ variable "availability_zones" {
 variable "aws_vpc_ipam_pool" {
   type        = string
   description = "ID of the IPAM pool to get CIDRs from."
-}
-
-# s3_flow_logs_configuration.log_destination accepts full S3 ARNs, optionally including keys. Example:
-# "s3://{bucket_name}/{key_name}" will create a folder in the S3 bucket with the {key_name}
-variable "s3_flow_logs_configuration" {
-  type = object({
-    bucket_name              = optional(string)
-    kms_key_arn              = string
-    log_destination          = optional(string)
-    log_format               = optional(string)
-    max_aggregation_interval = optional(number, 60)
-    retention_in_days        = optional(number, 90)
-    traffic_type             = optional(string, "ALL")
-
-    destination_options = optional(object({
-      file_format                = optional(string)
-      hive_compatible_partitions = optional(bool, false)
-      per_hour_partition         = optional(bool, true)
-    }), {})
-  })
-  default     = null
-  description = "Variables to enable S3 flow logs for the VPC. Use 'bucket_name' to log to an S3 bucket created by this module. Alternatively, use 'log_destination' to specify a self-managed S3 bucket. The 'log_destination' variable accepts full S3 ARNs, optionally including object keys."
-
-  validation {
-    condition     = var.s3_flow_logs_configuration == null || (try(var.s3_flow_logs_configuration.log_destination, null) != null || try(var.s3_flow_logs_configuration.bucket_name, null) != null)
-    error_message = "Either log_destination or bucket_name must be specified in s3_flow_logs_configuration if the configuration is provided."
-  }
 }
 
 variable "cloudwatch_flow_logs_configuration" {
@@ -101,6 +60,47 @@ variable "region" {
   description = "The AWS region where resources will be created; if omitted the default provider region is used"
 }
 
+variable "route53_profiles_association" {
+  type = object({
+    association_name = string
+    profile_id       = string
+  })
+  default     = null
+  description = "Variable to enable Route53 Profile association. Specify the 'profile_id' of a Route53 Profile in the account to associate with the VPC, and an arbitrary 'association_name'. Note: AWS only supports one Route53 Profile per VPC."
+
+  validation {
+    condition     = var.route53_profiles_association == null ? true : (can(regex("^[a-zA-Z0-9\\-_ ']+$", var.route53_profiles_association.association_name)) && !can(regex("^[0-9]+$", var.route53_profiles_association.association_name)))
+    error_message = "association_name must match (?!^[0-9]+$)([a-zA-Z0-9\\-_ ']+) (not purely numeric)."
+  }
+}
+
+# s3_flow_logs_configuration.log_destination accepts full S3 ARNs, optionally including keys. Example:
+# "s3://{bucket_name}/{key_name}" will create a folder in the S3 bucket with the {key_name}
+variable "s3_flow_logs_configuration" {
+  type = object({
+    bucket_name              = optional(string)
+    kms_key_arn              = string
+    log_destination          = optional(string)
+    log_format               = optional(string)
+    max_aggregation_interval = optional(number, 60)
+    retention_in_days        = optional(number, 90)
+    traffic_type             = optional(string, "ALL")
+
+    destination_options = optional(object({
+      file_format                = optional(string)
+      hive_compatible_partitions = optional(bool, false)
+      per_hour_partition         = optional(bool, true)
+    }), {})
+  })
+  default     = null
+  description = "Variables to enable S3 flow logs for the VPC. Use 'bucket_name' to log to an S3 bucket created by this module. Alternatively, use 'log_destination' to specify a self-managed S3 bucket. The 'log_destination' variable accepts full S3 ARNs, optionally including object keys."
+
+  validation {
+    condition     = var.s3_flow_logs_configuration == null || (try(var.s3_flow_logs_configuration.log_destination, null) != null || try(var.s3_flow_logs_configuration.bucket_name, null) != null)
+    error_message = "Either log_destination or bucket_name must be specified in s3_flow_logs_configuration if the configuration is provided."
+  }
+}
+
 variable "tags" {
   type        = map(string)
   default     = {}
@@ -141,4 +141,38 @@ variable "vpc_cidr_netmask" {
   type        = number
   default     = 20
   description = "The netmask length of the IPv4 CIDR you want to allocate to this VPC."
+}
+
+variable "vpc_endpoints" {
+  type = object({
+    endpoints = optional(map(object({
+      auto_accept          = optional(bool)
+      ip_address_type      = optional(string)
+      policy               = optional(string)
+      private_dns_enabled  = optional(bool, true)
+      centralized_endpoint = optional(bool, false)
+      security_group_ids   = optional(list(string), [])
+      service              = optional(string)
+      service_full_name    = optional(string)
+      service_region       = optional(string)
+      type                 = optional(string, "Interface")
+
+      dns_options = optional(object({
+        dns_record_ip_type                             = optional(string)
+        private_dns_only_for_inbound_resolver_endpoint = optional(bool)
+      }))
+
+      private_link_dns_options = optional(object({
+        dns_record_ttl  = optional(number, 300)
+        dns_record_type = optional(string, "CNAME")
+        dns_records     = optional(list(string), [])
+        dns_zone        = string
+      }))
+    })), {})
+
+    security_group_ids = optional(list(string), [])
+  })
+
+  default     = null
+  description = "Configuration for VPC endpoints. When provided, the vpc-endpoints submodule is invoked automatically with the VPC ID, region, and Route53 profile ID derived from the root module. Gateway endpoints will automatically use the private subnet route table IDs, and Interface/GatewayLoadBalancer endpoints will automatically use the private subnet IDs."
 }


### PR DESCRIPTION
This pull request introduces support for configurable VPC endpoints and refactors variable definitions to improve clarity and maintainability. It adds a new `vpc_endpoints` variable and associated resources, and reorganizes the `variables.tf` file by moving and updating the `route53_profiles_association` and `s3_flow_logs_configuration` variables. The changes also include the creation of supporting security group resources for VPC endpoints.

### VPC Endpoints Support

* Added a new `vpc_endpoints` variable to allow configuration of VPC endpoints, including endpoint-specific options and associated security groups.
* Added a `vpc_endpoints` module block to instantiate the VPC endpoints submodule when the variable is provided.
* Created supporting resources: a security group and ingress rule for VPC endpoints, which are used if no security group IDs are provided.

### Variable Refactoring and Reorganization

* Moved the `route53_profiles_association` and `s3_flow_logs_configuration` variable definitions to a more logical position in `variables.tf`, improving readability and maintainability. [[1]](diffhunk://#diff-05b5a57c136b6ff596500bcbfdcff145ef6cddea2a0e86d184d9daa9a65a288eL1-L14) [[2]](diffhunk://#diff-05b5a57c136b6ff596500bcbfdcff145ef6cddea2a0e86d184d9daa9a65a288eL25-L51) [[3]](diffhunk://#diff-05b5a57c136b6ff596500bcbfdcff145ef6cddea2a0e86d184d9daa9a65a288eR63-R103)
* No functional changes to these variables, but their placement and grouping are improved for clarity. [[1]](diffhunk://#diff-05b5a57c136b6ff596500bcbfdcff145ef6cddea2a0e86d184d9daa9a65a288eL1-L14) [[2]](diffhunk://#diff-05b5a57c136b6ff596500bcbfdcff145ef6cddea2a0e86d184d9daa9a65a288eL25-L51) [[3]](diffhunk://#diff-05b5a57c136b6ff596500bcbfdcff145ef6cddea2a0e86d184d9daa9a65a288eR63-R103)

These changes make it easier to configure VPC endpoints and maintain the Terraform codebase.