### PR TITLE
fix: source flow-log policy account ID from the VPC instead of caller identity

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ This module will be merged with the [terraform-aws-mcaf-vpc](https://github.com/
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_log_bucket"></a> [log\_bucket](#module\_log\_bucket) | schubergphilis/mcaf-s3/aws | ~> 2.0.0 |
+| <a name="module_log_bucket"></a> [log\_bucket](#module\_log\_bucket) | schubergphilis/mcaf-s3/aws | ~> 3.0.0 |
 | <a name="module_vpc_endpoints"></a> [vpc\_endpoints](#module\_vpc\_endpoints) | ./modules/vpc-endpoints | n/a |
 
 ## Resources
@@ -64,7 +64,6 @@ This module will be merged with the [terraform-aws-mcaf-vpc](https://github.com/
 | [aws_vpc.default](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/vpc) | resource |
 | [aws_vpc_ipam_preview_next_cidr.vpc](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/vpc_ipam_preview_next_cidr) | resource |
 | [aws_vpc_security_group_ingress_rule.vpc_endpoints](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/vpc_security_group_ingress_rule) | resource |
-| [aws_caller_identity.default](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
 | [aws_iam_policy_document.vpc_flow_log](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.vpc_flow_logs_assume_role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_region.default](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/region) | data source |

--- a/data.tf
+++ b/data.tf
@@ -1,3 +1,1 @@
-data "aws_caller_identity" "default" {}
-
 data "aws_region" "default" {}

--- a/flowlogs_cloudwatch.tf
+++ b/flowlogs_cloudwatch.tf
@@ -58,7 +58,7 @@ data "aws_iam_policy_document" "vpc_flow_log" {
       "logs:DescribeLogStreams",
     ]
 
-    resources = ["arn:aws:logs:${local.region}:${data.aws_caller_identity.default.account_id}:log-group:*:*"]
+    resources = ["arn:aws:logs:${local.region}:${local.account_id}:log-group:*:*"]
   }
 }
 

--- a/flowlogs_s3.tf
+++ b/flowlogs_s3.tf
@@ -5,7 +5,7 @@ locals {
 
 module "log_bucket" {
   source  = "schubergphilis/mcaf-s3/aws"
-  version = "~> 2.0.0"
+  version = "~> 3.0.0"
 
   count = local.create_bucket ? 1 : 0
 
@@ -44,14 +44,14 @@ module "log_bucket" {
                 "Service": "delivery.logs.amazonaws.com"
             },
             "Action": "s3:PutObject",
-            "Resource": "arn:aws:s3:::${var.s3_flow_logs_configuration.bucket_name}/AWSLogs/${data.aws_caller_identity.default.account_id}/*",
+            "Resource": "arn:aws:s3:::${var.s3_flow_logs_configuration.bucket_name}/AWSLogs/${local.account_id}/*",
             "Condition": {
                 "StringEquals": {
-                    "aws:SourceAccount": "${data.aws_caller_identity.default.account_id}",
+                    "aws:SourceAccount": "${local.account_id}",
                     "s3:x-amz-acl": "bucket-owner-full-control"
                 },
                 "ArnLike": {
-                    "aws:SourceArn": "arn:aws:logs:${local.region}:${data.aws_caller_identity.default.account_id}:*"
+                    "aws:SourceArn": "arn:aws:logs:${local.region}:${local.account_id}:*"
                 }
             }
         },
@@ -65,10 +65,10 @@ module "log_bucket" {
             "Resource": "arn:aws:s3:::${var.s3_flow_logs_configuration.bucket_name}",
             "Condition": {
                 "StringEquals": {
-                    "aws:SourceAccount": "${data.aws_caller_identity.default.account_id}"
+                    "aws:SourceAccount": "${local.account_id}"
                 },
                 "ArnLike": {
-                    "aws:SourceArn": "arn:aws:logs:${local.region}:${data.aws_caller_identity.default.account_id}:*"
+                    "aws:SourceArn": "arn:aws:logs:${local.region}:${local.account_id}:*"
                 }
             }
         }

--- a/locals.tf
+++ b/locals.tf
@@ -1,0 +1,36 @@
+locals {
+  # Account that owns the VPC, sourced from the created resource rather than `data.aws_caller_identity`.
+  # The data source resolves at plan time, and when this module runs under a provider that assumes a
+  # role into an account created in the same apply, that role_arn is unknown at plan time, so the AWS
+  # provider falls back to the caller's base credentials — baking the wrong account ID into the flow-log
+  # policies on the first apply. `owner_id` is computed from the VPC during apply, so it is always correct.
+  account_id   = aws_vpc.default.owner_id
+  cidr_subnets = cidrsubnets(aws_vpc_ipam_preview_next_cidr.vpc.cidr, local.networks[*].new_bits...)
+  region       = var.region != null ? var.region : data.aws_region.default.region
+
+  networks = flatten([
+    for i, network in var.networks : [
+      for az in var.availability_zones : {
+        availability_zone = az
+        key               = "${network.name}_${az}"
+        name              = network.name
+        nat_gw            = network.nat_gw
+        new_bits          = network.cidr_netmask - var.vpc_cidr_netmask
+        public            = network.public
+        tgw_attachment    = network.tgw_attachment
+        tags              = network.tags
+      }
+    ]]
+  )
+
+  vpc_subnets = [for i, n in local.networks : {
+    availability_zone = n.availability_zone
+    cidr_block        = n.key != null ? local.cidr_subnets[i] : tostring(null)
+    key               = n.key
+    name              = n.name
+    nat_gw            = n.nat_gw
+    public            = n.public
+    tgw_attachment    = n.tgw_attachment
+    tags              = n.tags
+  }]
+}

--- a/main.tf
+++ b/main.tf
@@ -1,34 +1,3 @@
-locals {
-  networks = flatten([
-    for i, network in var.networks : [
-      for az in var.availability_zones : {
-        availability_zone = az
-        key               = "${network.name}_${az}"
-        name              = network.name
-        nat_gw            = network.nat_gw
-        new_bits          = network.cidr_netmask - var.vpc_cidr_netmask
-        public            = network.public
-        tgw_attachment    = network.tgw_attachment
-        tags              = network.tags
-      }
-    ]]
-  )
-
-  cidr_subnets = cidrsubnets(aws_vpc_ipam_preview_next_cidr.vpc.cidr, local.networks[*].new_bits...)
-  region       = var.region != null ? var.region : data.aws_region.default.region
-
-  vpc_subnets = [for i, n in local.networks : {
-    availability_zone = n.availability_zone
-    cidr_block        = n.key != null ? local.cidr_subnets[i] : tostring(null)
-    key               = n.key
-    name              = n.name
-    nat_gw            = n.nat_gw
-    public            = n.public
-    tgw_attachment    = n.tgw_attachment
-    tags              = n.tags
-  }]
-}
-
 resource "aws_vpc_ipam_preview_next_cidr" "vpc" {
   region         = var.region
   ipam_pool_id   = var.aws_vpc_ipam_pool


### PR DESCRIPTION
## :hammer_and_wrench: Summary

The CloudWatch and S3 flow-log policies built their account ID from `data.aws_caller_identity.default`, a plan-time data source. When this module runs under an AWS provider that assumes a role into an account created in the *same* apply, that `role_arn` is unknown at plan time, so the provider falls back to the caller's base credentials — baking the **wrong account ID** into the flow-log policies on the first apply. It only self-corrects on a second apply.

## Fix
Source the account ID from `aws_vpc.default.owner_id` (a computed attribute, resolved during apply under the correct provider) via a new `local.account_id`. Replaces all 6 `data.aws_caller_identity.default.account_id` usages across `flowlogs_cloudwatch.tf` and `flowlogs_s3.tf`, and removes the now-unused data source from `data.tf`. No behaviour change for single-account/static-provider callers; first-apply correctness for assume-role-into-new-account callers.